### PR TITLE
Updated Readme.md to include Ubuntu specific requirement

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -127,6 +127,11 @@ As should be the case with any security tool, this library should be scrutinized
 
     npm install scrypt
 
+*Ubuntu requires `libssl-dev`. Install the libary using the following command:
+
+    sudo apt-get install libssl-dev
+
+
 ##From Source
 You will need `node-gyp` to get this to work (install it if you don't have it: `npm install -g node-gyp`):
 


### PR DESCRIPTION
Hi, I was trying to install the package using npm, then tried compiling the source but kept banging my head against the wall. Reviewing the errors I found out I didn't have a necessary lib installed on my (near) default Ubuntu 13.04. So, I believe adding these few lines will help newbs like me out in the future.

I was originally going to write "Linux requires ..." but some distros have it installed by default. Hence, the specific Ubuntu mention. Also, it installs without extra dependencies on my Mac just fine. (Mountain Lion and OpenSSL 0.9.8x)
