### PR TITLE
Double quote path

### DIFF
--- a/scrypt/configuration/posix_configuration/configure
+++ b/scrypt/configuration/posix_configuration/configure
@@ -2009,7 +2009,7 @@ program_transform_name=`$as_echo "$program_transform_name" | sed "$ac_script"`
 # expand $ac_aux_dir to an absolute path
 am_aux_dir=`cd $ac_aux_dir && pwd`
 
-test x"${MISSING+set}" = xset || MISSING="\${SHELL} $am_aux_dir/missing"
+test x"${MISSING+set}" = xset || MISSING="\${SHELL} '$am_aux_dir/missing'"
 # Use eval to expand $SHELL
 if eval "$MISSING --run true"; then
   am_missing_run="$MISSING --run "
@@ -6480,7 +6480,8 @@ $debug ||
 if test -n "$CONFIG_FILES"; then
 
 
-ac_cr=''
+ac_cr='
+'
 ac_cs_awk_cr=`$AWK 'BEGIN { print "a\rb" }' </dev/null 2>/dev/null`
 if test "$ac_cs_awk_cr" = "a${ac_cr}b"; then
   ac_cs_awk_cr='\\r'

--- a/scrypt/configuration/posixconfig
+++ b/scrypt/configuration/posixconfig
@@ -3,7 +3,7 @@
 
 SCRIPTPATH="$(pwd)/scrypt/configuration"
 mkdir "$SCRIPTPATH/config_output"
-cd "$SCRIPTPATH/config_output" && "$SCRIPTPATH/posix_configuration/configure"
+cd "$SCRIPTPATH/config_output" && "../posix_configuration/configure" -q
 echo '@LIBS@' | "$SCRIPTPATH/config_output/config.status" --file=-
 cp "$SCRIPTPATH/config_output/config.h" "$SCRIPTPATH/../config.h"
 #cp "$SCRIPTPATH/config_output/config.status" "$SCRIPTPATH/../config.status"


### PR DESCRIPTION
I believe I have fixed an issue where users with a full path containing spaces would see a failure when trying to install this module. This was corrected by double-quoting instances of the path, and surrounding the 'missing' path on line 2012 of /scrypt/configuration/posix_configuration/configure with quotes as well. This seemed to fix the problem for me.

-Cheers
