### PR TITLE
Don't hardcode nan paths, fixes #92

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -151,7 +151,7 @@
       'scrypt_node.cc'
     ],
     'include_dirs': [
-      'node_modules/nan',
+      '<!(node -e "require(\'nan\')")',
       'src/util',
       'src/scryptwrapper/inc',
       'src/node-boilerplate/inc'


### PR DESCRIPTION
As was seen in https://github.com/node-xmpp/node-expat/issues/78, there was a few issues with nan.

Following the commit trail I found this solved their issues, I tested it and it builds successfully for me right now. Works on node v4.1.0