### PR TITLE
Add range check for 'N' parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,10 @@ var checkScryptParametersObject = function(params) {
     var error = new TypeError("Scrypt params object 'N' property is not an integer");
   }
 
+  if (!error && !((params.N > 0) && (params.N < 256))) {
+    var error = new RangeError("Scrypt params object 'N' property is out of range");
+  }
+
   if (!error && !params.hasOwnProperty("r")) {
     var error = new TypeError("Scrypt params object does not have 'r' property present");
   }

--- a/tests/scrypt-tests.js
+++ b/tests/scrypt-tests.js
@@ -239,10 +239,16 @@ describe("Scrypt Node Module Tests", function() {
           .to.match(/^TypeError: Key type is incorrect: It can only be of type string or Buffer$/);
       })
 
-      it("Will throw a TypeError if the Scrypt params object is incorrect", function() {
+      it("Will throw a TypeError if the Scrypt params object is missing 'r' property", function() {
         expect(function(){scrypt.kdfSync("password", {N:1, p:1})})
           .to.throw(TypeError)
           .to.match(/^TypeError: Scrypt params object does not have 'r' property present$/);
+      })
+
+      it("Will throw a TypeError if the Scrypt params object has 'N' property out of range", function() {
+        expect(function(){scrypt.kdfSync("password", {N:65536, r:1, p:1})})
+          .to.throw(RangeError)
+          .to.match(/^RangeError: Scrypt params object 'N' property is out of range$/);
       })
     });
 


### PR DESCRIPTION
Colin Percival has a 'sanity check' that 0 < logN < 256: see
https://github.com/Tarsnap/scrypt/blob/484dc1fb/lib/scryptenc/scryptenc.c#L206.

Since the 'N' parameter in node-scrypt is the canonical scrypt logN, it is
useful to trap the canonical 'N' being passed as early as possible, and to
report it more helpfully than 'error computing derived key'.

Following this commit, if a call is erroneously made to
    scrypt.kdf('abc', { N: 65536, r: 8, p: 1 })
it will immediately have a RangeError thrown.