### PR TITLE
scrypt: move to nan ^2.14.0; fix node 12+ support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "chai-as-promised": "^5.1.0"
   },
   "dependencies": {
-    "nan": "^2.0.8"
+    "nan": "^2.14.0"
   },
   "licenses": [
     {

--- a/src/node-boilerplate/inc/scrypt_async.h
+++ b/src/node-boilerplate/inc/scrypt_async.h
@@ -50,7 +50,7 @@ class ScryptAsyncWorker : public Nan::AsyncWorker {
       v8::Local<v8::Value> argv[] = {
           NodeScrypt::ScryptError(result)
       };
-      callback->Call(1, argv);
+      callback->Call(1, argv, async_resource);
     }
 
     //

--- a/src/node-boilerplate/inc/scrypt_common.h
+++ b/src/node-boilerplate/inc/scrypt_common.h
@@ -36,9 +36,9 @@ namespace NodeScrypt {
     const uint32_t p;
 
     Params(const v8::Local<v8::Object> &obj) :
-      N(obj->Get(Nan::New("N").ToLocalChecked())->Uint32Value()),
-      r(obj->Get(Nan::New("r").ToLocalChecked())->Uint32Value()),
-      p(obj->Get(Nan::New("p").ToLocalChecked())->Uint32Value()) {}
+      N(Nan::To<uint32_t>(obj->Get(Nan::New("N").ToLocalChecked())).ToChecked()),
+      r(Nan::To<uint32_t>(obj->Get(Nan::New("r").ToLocalChecked())).ToChecked()),
+      p(Nan::To<uint32_t>(obj->Get(Nan::New("p").ToLocalChecked())).ToChecked()) {}
   };
 
   //

--- a/src/node-boilerplate/inc/scrypt_common.h
+++ b/src/node-boilerplate/inc/scrypt_common.h
@@ -36,9 +36,9 @@ namespace NodeScrypt {
     const uint32_t p;
 
     Params(const v8::Local<v8::Object> &obj) :
-      N(Nan::To<uint32_t>(obj->Get(Nan::New("N").ToLocalChecked())).ToChecked()),
-      r(Nan::To<uint32_t>(obj->Get(Nan::New("r").ToLocalChecked())).ToChecked()),
-      p(Nan::To<uint32_t>(obj->Get(Nan::New("p").ToLocalChecked())).ToChecked()) {}
+      N(Nan::To<uint32_t>(Nan::Get(obj, Nan::New("N").ToLocalChecked()).ToLocalChecked()).ToChecked()),
+      r(Nan::To<uint32_t>(Nan::Get(obj, Nan::New("r").ToLocalChecked()).ToLocalChecked()).ToChecked()),
+      p(Nan::To<uint32_t>(Nan::Get(obj, Nan::New("p").ToLocalChecked()).ToLocalChecked()).ToChecked()) {}
   };
 
   //

--- a/src/node-boilerplate/inc/scrypt_hash_async.h
+++ b/src/node-boilerplate/inc/scrypt_hash_async.h
@@ -39,12 +39,12 @@ class ScryptHashAsyncWorker : public ScryptAsyncWorker {
       salt_size(static_cast<size_t>(node::Buffer::Length(info[3])))
     {
       ScryptPeristentObject = Nan::New<v8::Object>();
-      ScryptPeristentObject->Set(Nan::New("KeyBuffer").ToLocalChecked(), info[0]);
-      ScryptPeristentObject->Set(Nan::New("HashBuffer").ToLocalChecked(), Nan::NewBuffer(static_cast<uint32_t>(hash_size)).ToLocalChecked());
-      ScryptPeristentObject->Set(Nan::New("SaltBuffer").ToLocalChecked(), info[3]);
+      Nan::Set(ScryptPeristentObject, Nan::New("KeyBuffer").ToLocalChecked(), info[0]);
+      Nan::Set(ScryptPeristentObject, Nan::New("HashBuffer").ToLocalChecked(), Nan::NewBuffer(static_cast<uint32_t>(hash_size)).ToLocalChecked());
+      Nan::Set(ScryptPeristentObject, Nan::New("SaltBuffer").ToLocalChecked(), info[3]);
       SaveToPersistent("ScryptPeristentObject", ScryptPeristentObject);
 
-      hash_ptr = reinterpret_cast<uint8_t*>(node::Buffer::Data(ScryptPeristentObject->Get(Nan::New("HashBuffer").ToLocalChecked())));
+      hash_ptr = reinterpret_cast<uint8_t*>(node::Buffer::Data(Nan::Get(ScryptPeristentObject, Nan::New("HashBuffer").ToLocalChecked()).ToLocalChecked()));
     };
 
     void Execute();

--- a/src/node-boilerplate/inc/scrypt_hash_async.h
+++ b/src/node-boilerplate/inc/scrypt_hash_async.h
@@ -33,8 +33,8 @@ class ScryptHashAsyncWorker : public ScryptAsyncWorker {
       ScryptAsyncWorker(new Nan::Callback(info[4].As<v8::Function>())),
       key_ptr(reinterpret_cast<uint8_t*>(node::Buffer::Data(info[0]))),
       key_size(node::Buffer::Length(info[0])),
-      params(info[1]->ToObject()),
-      hash_size(info[2]->IntegerValue()),
+      params(Nan::To<v8::Object>(info[1]).ToLocalChecked()),
+      hash_size(Nan::To<int64_t>(info[2]).ToChecked()),
       salt_ptr(reinterpret_cast<uint8_t*>(node::Buffer::Data(info[3]))),
       salt_size(static_cast<size_t>(node::Buffer::Length(info[3])))
     {

--- a/src/node-boilerplate/inc/scrypt_kdf-verify_async.h
+++ b/src/node-boilerplate/inc/scrypt_kdf-verify_async.h
@@ -37,8 +37,8 @@ class ScryptKDFVerifyAsyncWorker : public ScryptAsyncWorker {
       match(false)
     {
       ScryptPeristentObject = Nan::New<v8::Object>();
-      ScryptPeristentObject->Set(Nan::New("KDFBuffer").ToLocalChecked(), info[0]);
-      ScryptPeristentObject->Set(Nan::New("KeyBuffer").ToLocalChecked(), info[1]);
+      Nan::Set(ScryptPeristentObject, Nan::New("KDFBuffer").ToLocalChecked(), info[0]);
+      Nan::Set(ScryptPeristentObject, Nan::New("KeyBuffer").ToLocalChecked(), info[1]);
       SaveToPersistent("ScryptPeristentObject", ScryptPeristentObject);
     };
 

--- a/src/node-boilerplate/inc/scrypt_kdf_async.h
+++ b/src/node-boilerplate/inc/scrypt_kdf_async.h
@@ -37,12 +37,12 @@ class ScryptKDFAsyncWorker : public ScryptAsyncWorker {
       salt_ptr(reinterpret_cast<uint8_t*>(node::Buffer::Data(args[2])))
     {
       ScryptPeristentObject = Nan::New<v8::Object>();
-      ScryptPeristentObject->Set(Nan::New("keyBuffer").ToLocalChecked(), args[0]);
-      ScryptPeristentObject->Set(Nan::New("KDFResult").ToLocalChecked(), Nan::NewBuffer(96).ToLocalChecked());
-      ScryptPeristentObject->Set(Nan::New("salt").ToLocalChecked(), args[2]);
+      Nan::Set(ScryptPeristentObject, Nan::New("keyBuffer").ToLocalChecked(), args[0]);
+      Nan::Set(ScryptPeristentObject, Nan::New("KDFResult").ToLocalChecked(), Nan::NewBuffer(96).ToLocalChecked());
+      Nan::Set(ScryptPeristentObject, Nan::New("salt").ToLocalChecked(), args[2]);
       SaveToPersistent("ScryptPeristentObject", ScryptPeristentObject);
 
-      KDFResult_ptr = reinterpret_cast<uint8_t*>(node::Buffer::Data(ScryptPeristentObject->Get(Nan::New("KDFResult").ToLocalChecked())));
+      KDFResult_ptr = reinterpret_cast<uint8_t*>(node::Buffer::Data(Nan::Get(ScryptPeristentObject, Nan::New("KDFResult").ToLocalChecked()).ToLocalChecked()));
     };
 
     void Execute();

--- a/src/node-boilerplate/inc/scrypt_kdf_async.h
+++ b/src/node-boilerplate/inc/scrypt_kdf_async.h
@@ -33,7 +33,7 @@ class ScryptKDFAsyncWorker : public ScryptAsyncWorker {
       ScryptAsyncWorker(new Nan::Callback(args[3].As<v8::Function>())),
       key_ptr(reinterpret_cast<uint8_t*>(node::Buffer::Data(args[0]))),
       key_size(node::Buffer::Length(args[0])),
-      params(args[1]->ToObject()),
+      params(Nan::To<v8::Object>(args[1]).ToLocalChecked()),
       salt_ptr(reinterpret_cast<uint8_t*>(node::Buffer::Data(args[2])))
     {
       ScryptPeristentObject = Nan::New<v8::Object>();

--- a/src/node-boilerplate/inc/scrypt_params_async.h
+++ b/src/node-boilerplate/inc/scrypt_params_async.h
@@ -32,10 +32,10 @@ class ScryptParamsAsyncWorker : public ScryptAsyncWorker {
   public:
     ScryptParamsAsyncWorker(Nan::NAN_METHOD_ARGS_TYPE info) :
       ScryptAsyncWorker(new Nan::Callback(info[4].As<v8::Function>())),
-      maxtime(info[0]->NumberValue()),
-      maxmemfrac(info[1]->NumberValue()),
-      maxmem(info[2]->IntegerValue()),
-      osfreemem(info[3]->IntegerValue())
+      maxtime(Nan::To<double>(info[0]).ToChecked()),
+      maxmemfrac(Nan::To<double>(info[1]).ToChecked()),
+      maxmem(Nan::To<int64_t>(info[2]).ToChecked()),
+      osfreemem(Nan::To<int64_t>(info[3]).ToChecked())
     {
       logN = 0;
       r = 0;

--- a/src/node-boilerplate/scrypt_hash_async.cc
+++ b/src/node-boilerplate/scrypt_hash_async.cc
@@ -46,7 +46,7 @@ void ScryptHashAsyncWorker::HandleOKCallback() {
 
   Local<Value> argv[] = {
     Nan::Null(),
-    GetFromPersistent("ScryptPeristentObject")->ToObject()->Get(Nan::New("HashBuffer").ToLocalChecked())
+    Nan::To<v8::Object>(GetFromPersistent("ScryptPeristentObject")).ToLocalChecked()->Get(Nan::New("HashBuffer").ToLocalChecked())
   };
 
   callback->Call(2, argv);

--- a/src/node-boilerplate/scrypt_hash_async.cc
+++ b/src/node-boilerplate/scrypt_hash_async.cc
@@ -46,10 +46,10 @@ void ScryptHashAsyncWorker::HandleOKCallback() {
 
   Local<Value> argv[] = {
     Nan::Null(),
-    Nan::To<v8::Object>(GetFromPersistent("ScryptPeristentObject")).ToLocalChecked()->Get(Nan::New("HashBuffer").ToLocalChecked())
+    Nan::Get(Nan::To<v8::Object>(GetFromPersistent("ScryptPeristentObject")).ToLocalChecked(), Nan::New("HashBuffer").ToLocalChecked()).ToLocalChecked()
   };
 
-  callback->Call(2, argv);
+  callback->Call(2, argv, async_resource);
 }
 
 //

--- a/src/node-boilerplate/scrypt_hash_sync.cc
+++ b/src/node-boilerplate/scrypt_hash_sync.cc
@@ -21,8 +21,8 @@ NAN_METHOD(hashSync) {
   //
   const uint8_t* key_ptr = reinterpret_cast<uint8_t*>(node::Buffer::Data(info[0]));
   const size_t key_size = node::Buffer::Length(info[0]);
-  const NodeScrypt::Params params = info[1]->ToObject();
-  const size_t hash_size = info[2]->IntegerValue();
+  const NodeScrypt::Params params = Nan::To<v8::Object>(info[1]).ToLocalChecked();
+  const size_t hash_size = Nan::To<int64_t>(info[2]).ToChecked();
   const uint8_t* salt_ptr = reinterpret_cast<uint8_t*>(node::Buffer::Data(info[3]));
   const size_t salt_size = node::Buffer::Length(info[3]);
 

--- a/src/node-boilerplate/scrypt_kdf-verify_async.cc
+++ b/src/node-boilerplate/scrypt_kdf-verify_async.cc
@@ -27,7 +27,7 @@ void ScryptKDFVerifyAsyncWorker::HandleOKCallback() {
     (match) ? Nan::True() : Nan::False()
   };
 
-  callback->Call(2, argv);
+  callback->Call(2, argv, async_resource);
 }
 
 NAN_METHOD(kdfVerify) {

--- a/src/node-boilerplate/scrypt_kdf_async.cc
+++ b/src/node-boilerplate/scrypt_kdf_async.cc
@@ -22,10 +22,10 @@ void ScryptKDFAsyncWorker::HandleOKCallback() {
 
     Local<Value> argv[] = {
         Nan::Null(),
-        Nan::To<v8::Object>(GetFromPersistent("ScryptPeristentObject")).ToLocalChecked()->Get(Nan::New("KDFResult").ToLocalChecked())
+        Nan::Get(Nan::To<v8::Object>(GetFromPersistent("ScryptPeristentObject")).ToLocalChecked(), Nan::New("KDFResult").ToLocalChecked()).ToLocalChecked()
     };
 
-    callback->Call(2, argv);
+    callback->Call(2, argv, async_resource);
 }
 
 // Asynchronous access to scrypt params

--- a/src/node-boilerplate/scrypt_kdf_async.cc
+++ b/src/node-boilerplate/scrypt_kdf_async.cc
@@ -22,7 +22,7 @@ void ScryptKDFAsyncWorker::HandleOKCallback() {
 
     Local<Value> argv[] = {
         Nan::Null(),
-        GetFromPersistent("ScryptPeristentObject")->ToObject()->Get(Nan::New("KDFResult").ToLocalChecked())
+        Nan::To<v8::Object>(GetFromPersistent("ScryptPeristentObject")).ToLocalChecked()->Get(Nan::New("KDFResult").ToLocalChecked())
     };
 
     callback->Call(2, argv);

--- a/src/node-boilerplate/scrypt_kdf_sync.cc
+++ b/src/node-boilerplate/scrypt_kdf_sync.cc
@@ -26,7 +26,7 @@ NAN_METHOD(kdfSync) {
     //
     const uint8_t* key_ptr = reinterpret_cast<uint8_t*>(node::Buffer::Data(info[0])); //assume info[0] is a buffer (checked in JS land)
     const size_t keySize = node::Buffer::Length(info[0]);
-    const NodeScrypt::Params params = info[1]->ToObject();
+    const NodeScrypt::Params params = Nan::To<v8::Object>(info[1]).ToLocalChecked();
     const uint8_t* salt_ptr = reinterpret_cast<uint8_t*>(node::Buffer::Data(info[2]));
 
     //

--- a/src/node-boilerplate/scrypt_params_async.cc
+++ b/src/node-boilerplate/scrypt_params_async.cc
@@ -20,16 +20,16 @@ void ScryptParamsAsyncWorker::HandleOKCallback() {
 
   // Returned params in JSON object
   Local <Object> obj = Nan::New<Object>();
-  obj->Set(Nan::New("N").ToLocalChecked(), Nan::New<Integer>(logN));
-  obj->Set(Nan::New("r").ToLocalChecked(), Nan::New<Integer>(r));
-  obj->Set(Nan::New("p").ToLocalChecked(), Nan::New<Integer>(p));
+  Nan::Set(obj, Nan::New("N").ToLocalChecked(), Nan::New<Integer>(logN));
+  Nan::Set(obj, Nan::New("r").ToLocalChecked(), Nan::New<Integer>(r));
+  Nan::Set(obj, Nan::New("p").ToLocalChecked(), Nan::New<Integer>(p));
 
   Local<Value> argv[] = {
     Nan::Null(),
     obj
   };
 
-  callback->Call(2, argv);
+  callback->Call(2, argv, async_resource);
 }
 
 // Asynchronous access to scrypt params

--- a/src/node-boilerplate/scrypt_params_sync.cc
+++ b/src/node-boilerplate/scrypt_params_sync.cc
@@ -43,9 +43,9 @@ NAN_METHOD(paramsSync) {
   // Return values in JSON object
   //
   Local <Object> obj = Nan::New<Object>();
-  obj->Set(Nan::New("N").ToLocalChecked(), Nan::New<Integer>(logN));
-  obj->Set(Nan::New("r").ToLocalChecked(), Nan::New<Integer>(r));
-  obj->Set(Nan::New("p").ToLocalChecked(), Nan::New<Integer>(p));
+  Nan::Set(obj, Nan::New("N").ToLocalChecked(), Nan::New<Integer>(logN));
+  Nan::Set(obj, Nan::New("r").ToLocalChecked(), Nan::New<Integer>(r));
+  Nan::Set(obj, Nan::New("p").ToLocalChecked(), Nan::New<Integer>(p));
 
   info.GetReturnValue().Set(obj);
 }

--- a/src/node-boilerplate/scrypt_params_sync.cc
+++ b/src/node-boilerplate/scrypt_params_sync.cc
@@ -22,10 +22,10 @@ NAN_METHOD(paramsSync) {
   //
   // Arguments from JavaScript
   //
-  const double maxtime = info[0]->NumberValue();
-  const size_t maxmem = info[2]->IntegerValue();
-  const double maxmemfrac = info[1]->NumberValue();
-  const size_t osfreemem = info[3]->IntegerValue();
+  const double maxtime = Nan::To<double>(info[0]).ToChecked();
+  const size_t maxmem = Nan::To<int64_t>(info[2]).ToChecked();
+  const double maxmemfrac = Nan::To<double>(info[1]).ToChecked();
+  const size_t osfreemem = Nan::To<int64_t>(info[3]).ToChecked();
 
   //
   // Scrypt: calculate input parameters


### PR DESCRIPTION
Node.js 12 bundles a version of v8 with lots of breaking changes, with more coming.
As such, things were moved around in NAN.

This updates node-scrypt to the latest NAN and fixes the build breakage under Node 12.

Also, fix all remaining build warnings to future-proof upcoming v8 changes.

closes #193 